### PR TITLE
remove `solana-frozen-abi` from stub deps

### DIFF
--- a/libraries/solana-address-lookup-table-program-gateway/Cargo.toml
+++ b/libraries/solana-address-lookup-table-program-gateway/Cargo.toml
@@ -12,7 +12,7 @@ full = [
 ]
 stub-id = ["solana-program"]
 stub-instruction = ["stub-id", "serde"]
-stub-state = ["stub-id", "serde", "bincode", "solana-frozen-abi-macro", "bytemuck"]
+stub-state = ["stub-id", "serde", "bincode", "bytemuck"]
 stub-all = ["stub-id", "stub-instruction", "stub-state"]
 default = []
 
@@ -28,7 +28,6 @@ solana-address-lookup-table-program = { version = "1.14", optional = true }
 solana-program = { version = "1.14", optional = true }
 serde = { version = "1.0.138", features = ["derive"], optional = true }
 bincode = { version = "1.3.3", optional = true }
-solana-frozen-abi-macro = { version = "1.14", optional = true }
 bytemuck = { version = "1.12.3", optional = true }
 
 [dev-dependencies]

--- a/libraries/solana-address-lookup-table-program-gateway/src/stub/state.rs
+++ b/libraries/solana-address-lookup-table-program-gateway/src/stub/state.rs
@@ -3,25 +3,24 @@
 use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
-use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use solana_program::{instruction::InstructionError, pubkey::Pubkey, slot_history::Slot};
 
 const LOOKUP_TABLE_META_SIZE: usize = 56;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample, AbiEnumVisitor)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[allow(clippy::large_enum_variant)]
 enum ProgramState {
     Uninitialized,
     LookupTable(LookupTableMeta),
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, AbiExample)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AddressLookupTable<'a> {
     pub meta: LookupTableMeta,
     pub addresses: Cow<'a, [Pubkey]>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct LookupTableMeta {
     pub deactivation_slot: Slot,
     pub last_extended_slot: Slot,


### PR DESCRIPTION
The library `solana-frozen-abi` seems to sometimes have some issues when building for platforms like wasm. Since it doesn't appear to be necessary for a stub, removing to improve the cross target building experience.